### PR TITLE
Nice function, but let's just panic on errors

### DIFF
--- a/create-hostname/main.go
+++ b/create-hostname/main.go
@@ -68,10 +68,6 @@ func main() {
 	// TODO: Validate SECRET
 	secret := arguments["SECRET"].(string)
 
-	name, err := hostname.New(ip, subdomain, expires, secret)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "create-hostname: ERR 69: Unexpected error occurred: '%s'\n", err)
-		os.Exit(69)
-	}
+	name := hostname.New(ip, subdomain, expires, secret)
 	fmt.Println(name)
 }


### PR DESCRIPTION
Looking up the source it seems that this error won't happen :)
See: https://golang.org/src/bytes/buffer.go?s=4568:4619#L122

But the grow() function can panic if for some reason we run out of memory, I find that unlikely...
Anyways, I suggest we panic if we get an error, this can only happen if the API implementation changes in the future...
