### PR TITLE
Support decoding hostnames without signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,13 @@ __Source installation__
 
 Requirements:
 
-  * go (golang) v1.4 or higher
-  * `${GOPATH}/bin` is in your path
+  * go (golang) v1.17 or higher
+  * `$(go env GOPATH)/bin` is in your path
 
 Run:
 
 ```
-go get github.com/taskcluster/stateless-dns-go/...
+go install github.com/taskcluster/stateless-dns-go/...@latest
 ```
 
 Command line usage
@@ -131,14 +131,14 @@ Exit Codes:
 
 Example:
   $ create-hostname --ip 203.115.35.2 --subdomain foo.com --expires 2016-06-04T16:04:03.739Z --secret 'cheese monkey'
-  znzsgaqaau2hl7h35f4owqn25s76j4h7apm3fe4qpy6pfxjk.foo.com
+  znzsgaqaaaavkhbigan6of6sjltgr47okqtriauwfs3agzkj.foo.com
 ```
 
 Decoding hostnames...
 
 ```
 Usage:
-  decode-hostname --fqdn FQDN --subdomain SUBDOMAIN --secret SECRET
+  decode-hostname --fqdn FQDN --subdomain SUBDOMAIN [ --secret SECRET ]
   decode-hostname --help|-h
   decode-hostname --version
 
@@ -146,11 +146,16 @@ Exit Codes:
    0: Success
    1: Unrecognised command line options
 
-Example:
+Examples:
   $ decode-hostname --fqdn aebagbaaaaadqfbf6nanb2v3zyzdeq27biltfievlqaktog2.foo.com --subdomain foo.com --secret 'Happy Birthday Pete!'
   2017/01/10 18:50:08 IP: 1.2.3.4
   2017/01/10 18:50:08 Expires: 1977-08-19 16:30:00 +0000 UTC
   2017/01/10 18:50:08 Salt: [2]uint8{0xd0, 0xea}
+  $ decode-hostname --fqdn aebagbaaaaadqfbf6nanb2v3zyzdeq27biltfievlqaktog2.foo.com --subdomain foo.com
+  2017/01/10 18:50:08 IP: 1.2.3.4
+  2017/01/10 18:50:08 Expires: 1977-08-19 16:30:00 +0000 UTC
+  2017/01/10 18:50:08 Salt: [2]uint8{0xd0, 0xea}
+  2017/01/10 18:50:08 NO SECRET GIVEN TO VERIFY SIGNATURE !!
 ```
 
 License

--- a/decode-hostname/main.go
+++ b/decode-hostname/main.go
@@ -14,7 +14,7 @@ var (
 	version = "decode-hostname 1.0.6"
 	usage   = `
 Usage:
-  decode-hostname --fqdn FQDN --subdomain SUBDOMAIN --secret SECRET
+  decode-hostname --fqdn FQDN --subdomain SUBDOMAIN [ --secret SECRET ]
   decode-hostname --help|-h
   decode-hostname --version
 
@@ -22,11 +22,16 @@ Exit Codes:
    0: Success
    1: Unrecognised command line options
 
-Example:
+Examples:
   $ decode-hostname --fqdn aebagbaaaaadqfbf6nanb2v3zyzdeq27biltfievlqaktog2.foo.com --subdomain foo.com --secret 'Happy Birthday Pete!'
   2017/01/10 18:50:08 IP: 1.2.3.4
   2017/01/10 18:50:08 Expires: 1977-08-19 16:30:00 +0000 UTC
   2017/01/10 18:50:08 Salt: [2]uint8{0xd0, 0xea}
+  $ decode-hostname --fqdn aebagbaaaaadqfbf6nanb2v3zyzdeq27biltfievlqaktog2.foo.com --subdomain foo.com
+  2017/01/10 18:50:08 IP: 1.2.3.4
+  2017/01/10 18:50:08 Expires: 1977-08-19 16:30:00 +0000 UTC
+  2017/01/10 18:50:08 Salt: [2]uint8{0xd0, 0xea}
+  2017/01/10 18:50:08 NO SECRET GIVEN TO VERIFY SIGNATURE !!
 `
 )
 
@@ -40,9 +45,13 @@ func main() {
 
 	fqdn := arguments["FQDN"].(string)
 	subdomain := arguments["SUBDOMAIN"].(string)
-	secret := arguments["SECRET"].(string)
 
-	ip, expires, salt, err := hostname.Decode(fqdn, secret, subdomain)
+	secret := ""
+	if val := arguments["SECRET"]; val != nil {
+		secret = val.(string)
+	}
+
+	ip, expires, salt, verified, err := hostname.Decode(fqdn, secret, subdomain)
 
 	if err != nil {
 		log.Fatalf("Error occured: %v", err)
@@ -51,4 +60,7 @@ func main() {
 	log.Printf("IP: %v", ip)
 	log.Printf("Expires: %v", expires)
 	log.Printf("Salt: %#v", salt)
+	if !verified {
+		log.Printf("NO SECRET GIVEN TO VERIFY SIGNATURE !!")
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/taskcluster/stateless-dns-go
+
+go 1.17
+
+require github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 h1:bWDMxwH3px2JBh6AyO7hdCn/PkvCZXii8TGj7sbtEbQ=
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=

--- a/hostname/hostname.go
+++ b/hostname/hostname.go
@@ -105,26 +105,30 @@ func getHash(content []byte, secret string) []byte {
 // stateless dns naming scheme, and returns its IP, expiry time and salt. If
 // the hostname is invalid for any reason, an error will be returned explaining
 // the cause.
-func Decode(fqdn, secret, subdomain string) (ip net.IP, expires time.Time, salt [2]byte, err error) {
+func Decode(fqdn, secret, subdomain string) (ip net.IP, expires time.Time, salt [2]byte, verified bool, err error) {
 	upperFQDN := strings.ToUpper(fqdn)
 	upperSubdomain := strings.ToUpper(subdomain)
 	if !strings.HasSuffix(upperFQDN, "."+upperSubdomain) {
-		return nil, time.Time{}, [2]byte{0, 0}, fmt.Errorf("Host %v is not valid - it does not have subdomain %v", fqdn, subdomain)
+		return nil, time.Time{}, [2]byte{0, 0}, false, fmt.Errorf("Host %v is not valid - it does not have subdomain %v", fqdn, subdomain)
 	}
 	label := upperFQDN[:len(upperFQDN)-len(upperSubdomain)-1]
 	bytes, err := base32.StdEncoding.DecodeString(label)
 	if err != nil {
-		return nil, time.Time{}, [2]byte{0, 0}, fmt.Errorf("Uppercase host label %v from FQDN %v is not valid base32 - %v", label, fqdn, err)
+		return nil, time.Time{}, [2]byte{0, 0}, false, fmt.Errorf("Uppercase host label %v from FQDN %v is not valid base32 - %v", label, fqdn, err)
 	}
 	if len(bytes) != 4+8+2+16 {
-		return nil, time.Time{}, [2]byte{0, 0}, fmt.Errorf("Decoded host label is not correct length (4+8+2+16 bytes) - it is %v bytes (%v)", len(bytes), label)
+		return nil, time.Time{}, [2]byte{0, 0}, false, fmt.Errorf("Decoded host label is not correct length (4+8+2+16 bytes) - it is %v bytes (%v)", len(bytes), label)
 	}
 	ip = net.IPv4(bytes[0], bytes[1], bytes[2], bytes[3])
 	var expiryInUnixMillis int64 = int64(bytes[4])<<56 + int64(bytes[5])<<48 + int64(bytes[6])<<40 + int64(bytes[7])<<32 + int64(bytes[8])<<24 + int64(bytes[9])<<16 + int64(bytes[10])<<8 + int64(bytes[11])
 	salt = [2]byte{bytes[12], bytes[13]}
-	hash := getHash(bytes[:14], secret)
-	if string(hash) != string(bytes[14:]) {
-		return nil, time.Time{}, [2]byte{0, 0}, fmt.Errorf("Unexpected hash %#v - was expecting %#v", hash, bytes[14:])
+	verified = false
+	if secret != "" {
+		hash := getHash(bytes[:14], secret)
+		if string(hash) != string(bytes[14:]) {
+			return nil, time.Time{}, [2]byte{0, 0}, false, fmt.Errorf("Unexpected hash %#v - was expecting %#v", hash, bytes[14:])
+		}
+		verified = true
 	}
-	return ip, time.Unix(expiryInUnixMillis/1000, 1e6*(expiryInUnixMillis%1000)).UTC(), salt, nil
+	return ip, time.Unix(expiryInUnixMillis/1000, 1e6*(expiryInUnixMillis%1000)).UTC(), salt, verified, nil
 }

--- a/hostname/hostname_test.go
+++ b/hostname/hostname_test.go
@@ -26,7 +26,7 @@ func TestEncodeDecode(t *testing.T) {
 	// encode
 	fqdn := hostname.New(ip, subdomain, expires, secret)
 	// decode
-	ip2, expires2, _, err := hostname.Decode(fqdn, secret, subdomain)
+	ip2, expires2, _, _, err := hostname.Decode(fqdn, secret, subdomain)
 	if err != nil {
 		t.Fatalf("Error when creating hostname: %v", err)
 	}
@@ -39,7 +39,7 @@ func TestEncodeDecode(t *testing.T) {
 }
 
 func ExampleDecode() {
-	ip, expires, salt, err := hostname.Decode("zmvtoaqaaaavkjlja2i2n2ligiol2idykqa3t7vk4vfakdv6.foo.com", "turnip4tea", "foo.com")
+	ip, expires, salt, _, err := hostname.Decode("zmvtoaqaaaavkjlja2i2n2ligiol2idykqa3t7vk4vfakdv6.foo.com", "turnip4tea", "foo.com")
 	if err != nil {
 		log.Fatalf("Not able to decode example hostname")
 	}
@@ -53,7 +53,7 @@ func ExampleDecode() {
 }
 
 func TestBadName(t *testing.T) {
-	_, _, _, err := hostname.Decode("zmvtoaqaaaavkjlja2i2n2ligiol2idykqa3t7vk4vfakdw6.foo.com", "turnip4tea", "foo.com")
+	_, _, _, _, err := hostname.Decode("zmvtoaqaaaavkjlja2i2n2ligiol2idykqa3t7vk4vfakdw6.foo.com", "turnip4tea", "foo.com")
 	if err == nil {
 		log.Fatalf("Was expecting an error as hash is invalid")
 	}


### PR DESCRIPTION
Make secret optional when decoding hostnames. Warning to appear if signature hasn't been verified. Useful for diagnosis of problems when signature is trusted (e.g. [bug 1749765](https://bugzilla.mozilla.org/show_bug.cgi?id=1749765#c1)).